### PR TITLE
Use a facter plugin to determine sudo version, rather than distribution s

### DIFF
--- a/lib/facter/sudo.rb
+++ b/lib/facter/sudo.rb
@@ -1,0 +1,13 @@
+Facter.add("sudoversion") do
+  ENV["PATH"]="/bin:/sbin:/usr/bin:/usr/sbin"
+
+  setcode do
+    output = `sudo -V 2>&1`
+    if $?.exitstatus.zero?
+      m = /Sudo version ([\d\.]+)/.match output
+      if m
+        m[1]
+      end
+    end
+  end
+end

--- a/manifests/classes/sudo-base.pp
+++ b/manifests/classes/sudo-base.pp
@@ -1,9 +1,6 @@
 class sudo::base {
-
-  include sudo::params
-
   package {"sudo":
-    ensure => $sudo::params::version,
+    ensure => "present",
   }
 
   file {"/etc/sudoers":
@@ -13,7 +10,7 @@ class sudo::base {
     mode   => 440,
   }
 
-  if versioncmp($sudo::params::majversion,'1.7.2') < 0 {
+  if versioncmp($sudoversion,'1.7.2') < 0 {
     #
     # Backward compatibility for version less than 1.7.2
     # 

--- a/manifests/definitions/sudo-directive.pp
+++ b/manifests/definitions/sudo-directive.pp
@@ -7,9 +7,7 @@ define sudo::directive (
   # sudo skipping file names that contain a "."
   $dname = regsubst($name, '\.', '-', 'G')
 
-  include sudo::params
-
-  if versioncmp($sudo::params::majversion,'1.7.2') < 0 {
+  if versioncmp($sudoversion,'1.7.2') < 0 {
 
     common::concatfilepart {$dname:
       ensure => $ensure,


### PR DESCRIPTION
Use a facter plugin to determine sudo version, rather than distribution specific knowledge

The downside to this is that distribution-specific knowledge
understands what version puppet COULD install or upgrade to.

The upside is that we stop maintaining a list of quickly-outdated
facts.

Note: I do not currently have access to a machine that lacks sudo, so I am not 100% sure what would happen if sudo had to be installed - would the fact be re-checked after package installation? Do we need to mark all of the files under the conditional as requiring the package?
