### PR TITLE
exec for visudo should include a path

### DIFF
--- a/manifests/definitions/sudo-directive.pp
+++ b/manifests/definitions/sudo-directive.pp
@@ -48,6 +48,7 @@ define sudo::directive (
   }
 
   exec {"sudo-syntax-check for file $dname":
+    path => "/bin:/sbin:/usr/bin:/usr/sbin",
     command     => "visudo -c -f /etc/sudoers.d/${dname} || ( rm -f /etc/sudoers.d/${dname} && exit 1)",
     refreshonly => true,
   }


### PR DESCRIPTION
Puppet throws a hissy fit if you don't have a path for a relative-ly exec'd
command.
