### PR TITLE
do not check directive syntax on ensure => absent

### DIFF
--- a/manifests/directive.pp
+++ b/manifests/directive.pp
@@ -39,7 +39,10 @@ define sudo::directive (
         ""      => undef,  
         default => $source,
       },
-      notify  => Exec["sudo-syntax-check for file $dname"],
+      notify  => $ensure ? {
+        'present' => Exec["sudo-syntax-check for file $dname"],
+        default   => undef,
+      },
       require => Package["sudo"],
     }
   


### PR DESCRIPTION
This allows omitting the directive when removing it. And it makes no
sense to check something we're about to remove.
