### PR TITLE
make sudoversion fact more robust

### DIFF
--- a/lib/facter/sudo.rb
+++ b/lib/facter/sudo.rb
@@ -1,6 +1,6 @@
 output = %x{sudo -V 2>&1}
 
-if $?.exitstatus and output.match(/Sudo version ([\d\.]+)/)
+if $?.exitstatus and output.match(/[Ss]udo[ \-][Vv]ersion ([\d\.]+)/)
 
   Facter.add("sudoversion") do
     setcode do


### PR DESCRIPTION
Depending on the locale of the system, 'sudo -V' doesn't output exactly
the same string. Since we're parsing that string using a regex, we need
to plan for these differences.
