### PR TITLE
Set a warning message in sudo::directive

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -12,11 +12,41 @@ define sudo::conf(
   $source = undef,
 ) {
 
-  # Call our sudo::directive with the right parameters
-  sudo::directive{ "${priority}_${name}":
-    ensure  => $ensure,
-    content => $content,
-    source  => $source,
+  # sudo skipping file names that contain a "."
+  $tname = regsubst($name, '\.', '-', 'G')
+  $dname = "${priority}_${tname}"
+
+  if versioncmp($::sudoversion,'1.7.2') >= 0 {
+
+    file {"/etc/sudoers.d/${dname}":
+      ensure  => $ensure,
+      owner   => root,
+      group   => root,
+      mode    => '0440',
+      content => $content ? {
+        ''      => undef,
+        default => $content,
+      },
+      source  => $source ? {
+        ''      => undef,
+        default => $source,
+      },
+      notify => $ensure ? {
+        'present' => Exec["sudo-syntax-check for file ${dname}"],
+        default   => undef,
+      },
+      require => Package['sudo'],
+    }
+
+  } else {
+
+    fail "sudo fragments via #includedir is only available since version 1.7.2 in Sudo[${name}]!"
+
+  }
+
+  exec {"sudo-syntax-check for file ${dname}":
+    command     => "visudo -c -f '/etc/sudoers.d/${dname}' || ( rm -f '/etc/sudoers.d/${dname}' && exit 1)",
+    refreshonly => true,
   }
 
 }

--- a/manifests/directive.pp
+++ b/manifests/directive.pp
@@ -4,40 +4,13 @@ define sudo::directive (
   $source  = ''
 ) {
 
-  # sudo skipping file names that contain a "."
-  $dname = regsubst($name, '\.', '-', 'G')
+  notify{ "The sudo::directive is deprecated and will be removed soon. Use sudo::conf instead": }
 
-  if versioncmp($::sudoversion,'1.7.2') >= 0 {
-
-    file {"/etc/sudoers.d/${dname}":
-      ensure  => $ensure,
-      owner   => root,
-      group   => root,
-      mode    => '0440',
-      content => $content ? {
-        ''      => undef,
-        default => $content,
-      },
-      source  => $source ? {
-        ''      => undef,
-        default => $source,
-      },
-      notify => $ensure ? {
-        'present' => Exec["sudo-syntax-check for file ${dname}"],
-        default   => undef,
-      },
-      require => Package['sudo'],
-    }
-
-  } else {
-
-    fail "sudo fragments via #includedir is only available since version 1.7.2 in Sudo[${name}]!"
-
-  }
-
-  exec {"sudo-syntax-check for file ${dname}":
-    command     => "visudo -c -f '/etc/sudoers.d/${dname}' || ( rm -f '/etc/sudoers.d/${dname}' && exit 1)",
-    refreshonly => true,
+  # Call our sudo::conf with the right parameters
+  sudo::conf{ "${name}":
+    ensure  => $ensure,
+    content => $content,
+    source  => $source,
   }
 
 }


### PR DESCRIPTION
Move the code from sudo::directive to sudo::conf, and use sudo::directive as a wrapper to sudo::conf, with a notify.
Notify the use of sudo::direcive, as it will be removed in the near futur. (not after end of Q1 2014)
