### PR TITLE
sudoers file: add default secure_path

### DIFF
--- a/templates/sudoers.erb
+++ b/templates/sudoers.erb
@@ -6,6 +6,7 @@ Defaults    env_reset
 Defaults    mailto=<%= sudo_mailto %>
 <% end -%>
 Defaults    always_set_home
+Defaults    secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 root  ALL=(ALL) ALL
 
 # This directive only works with version >= 1.7.2!


### PR DESCRIPTION
On Wheezy, secure_path is not set by default anymore (was set to a
hardcoded value in Squeeze). To make running commands without path
working again in Wheezy, we want to set a standard PATH value by
default.
